### PR TITLE
Hash buffer

### DIFF
--- a/source/Octodiff/Core/AggregateCopyOperationsDecorator.cs
+++ b/source/Octodiff/Core/AggregateCopyOperationsDecorator.cs
@@ -21,6 +21,11 @@ namespace Octodiff.Core
             this.decorated = decorated;
         }
 
+        public void Begin(IHashAlgorithm hashAlgorithm)
+        {
+            decorated.Begin(hashAlgorithm);
+        }
+
         public void WriteDataCommand(Stream source, long offset, long length)
         {
             FlushCurrentCopyCommand();
@@ -53,10 +58,10 @@ namespace Octodiff.Core
             bufferedCopy = new DataRange();
         }
 
-        public void Finish()
+        public void FinishCommands()
         {
             FlushCurrentCopyCommand();
-            decorated.Finish();
+            decorated.FinishCommands();
         }
     }
 }

--- a/source/Octodiff/Core/BinaryDeltaWriter.cs
+++ b/source/Octodiff/Core/BinaryDeltaWriter.cs
@@ -12,14 +12,21 @@ namespace Octodiff.Core
             writer = new BinaryWriter(stream);
         }
 
+        public void Begin(IHashAlgorithm hashAlgorithm)
+        {
+            WriteMetadata(hashAlgorithm, new byte[hashAlgorithm.HashLength]);
+        }
+
         public void WriteMetadata(IHashAlgorithm hashAlgorithm, byte[] expectedNewFileHash)
         {
+            writer.Seek(0, SeekOrigin.Begin);
             writer.Write(BinaryFormat.DeltaHeader);
             writer.Write(BinaryFormat.Version);
             writer.Write(hashAlgorithm.Name);
             writer.Write(expectedNewFileHash.Length);
             writer.Write(expectedNewFileHash);
             writer.Write(BinaryFormat.EndOfMetadata);
+            writer.Seek(0, SeekOrigin.End);
         }
 
         public void WriteCopyCommand(DataRange segment)
@@ -56,7 +63,7 @@ namespace Octodiff.Core
             }
         }
 
-        public void Finish()
+        public void FinishCommands()
         {
         }
     }

--- a/source/Octodiff/Core/HashAlgorithmWrapper.cs
+++ b/source/Octodiff/Core/HashAlgorithmWrapper.cs
@@ -25,5 +25,21 @@ namespace Octodiff.Core
         {
             return algorithm.ComputeHash(buffer, offset, length);
         }
+
+        public void TransformBlock(byte[] buffer, int length)
+        {
+            algorithm.TransformBlock(buffer, 0, length, buffer, 0);
+        }
+
+        public byte[] TransformFinal()
+        {
+            algorithm.TransformFinalBlock(new byte[0], 0, 0);
+            return algorithm.Hash;
+        }
+
+        public object Clone()
+        {
+            return SupportedAlgorithms.Hashing.Create(Name);
+        }
     }
 }

--- a/source/Octodiff/Core/HashAlgorithmWrapper.cs
+++ b/source/Octodiff/Core/HashAlgorithmWrapper.cs
@@ -26,9 +26,9 @@ namespace Octodiff.Core
             return algorithm.ComputeHash(buffer, offset, length);
         }
 
-        public void TransformBlock(byte[] buffer, int length)
+        public void TransformBlock(byte[] buffer, int offset, int length)
         {
-            algorithm.TransformBlock(buffer, 0, length, buffer, 0);
+            algorithm.TransformBlock(buffer, offset, length, buffer, offset);
         }
 
         public byte[] TransformFinal()

--- a/source/Octodiff/Core/IDeltaWriter.cs
+++ b/source/Octodiff/Core/IDeltaWriter.cs
@@ -4,9 +4,10 @@ namespace Octodiff.Core
 {
     public interface IDeltaWriter
     {
+        void Begin(IHashAlgorithm hashAlgorithm);
         void WriteMetadata(IHashAlgorithm hashAlgorithm, byte[] expectedNewFileHash);
         void WriteCopyCommand(DataRange segment);
         void WriteDataCommand(Stream source, long offset, long length);
-        void Finish();
+        void FinishCommands();
     }
 }

--- a/source/Octodiff/Core/IHashAlgorithm.cs
+++ b/source/Octodiff/Core/IHashAlgorithm.cs
@@ -9,7 +9,7 @@ namespace Octodiff.Core
         int HashLength { get; }
         byte[] ComputeHash(Stream stream);
         byte[] ComputeHash(byte[] buffer, int offset, int length);
-        void TransformBlock(byte[] buffer, int length);
+        void TransformBlock(byte[] buffer, int offset, int length);
         byte[] TransformFinal();
     }
 }

--- a/source/Octodiff/Core/IHashAlgorithm.cs
+++ b/source/Octodiff/Core/IHashAlgorithm.cs
@@ -1,12 +1,15 @@
+using System;
 using System.IO;
 
 namespace Octodiff.Core
 {
-    public interface IHashAlgorithm
+    public interface IHashAlgorithm : ICloneable
     {
         string Name { get; }
         int HashLength { get; }
         byte[] ComputeHash(Stream stream);
         byte[] ComputeHash(byte[] buffer, int offset, int length);
+        void TransformBlock(byte[] buffer, int length);
+        byte[] TransformFinal();
     }
 }

--- a/source/Octodiff/Core/ISignatureWriter.cs
+++ b/source/Octodiff/Core/ISignatureWriter.cs
@@ -4,6 +4,7 @@ namespace Octodiff.Core
 {
     public interface ISignatureWriter
     {
+        void WriteBegin(IHashAlgorithm hashAlgorithm, IRollingChecksum rollingChecksumAlgorithm);
         void WriteMetadata(IHashAlgorithm hashAlgorithm, IRollingChecksum rollingChecksumAlgorithm, byte[] hash);
         void WriteChunk(ChunkSignature signature);
     }
@@ -17,13 +18,20 @@ namespace Octodiff.Core
             this.signatureStream = new BinaryWriter(signatureStream);
         }
 
+        public void WriteBegin(IHashAlgorithm hashAlgorithm, IRollingChecksum rollingChecksumAlgorithm)
+        {
+            WriteMetadata(hashAlgorithm, rollingChecksumAlgorithm, new byte[hashAlgorithm.HashLength]);
+        }
+
         public void WriteMetadata(IHashAlgorithm hashAlgorithm, IRollingChecksum rollingChecksumAlgorithm, byte[] hash)
         {
+            signatureStream.Seek(0, SeekOrigin.Begin);
             signatureStream.Write(BinaryFormat.SignatureHeader);
             signatureStream.Write(BinaryFormat.Version);
             signatureStream.Write(hashAlgorithm.Name);
             signatureStream.Write(rollingChecksumAlgorithm.Name);
             signatureStream.Write(BinaryFormat.EndOfMetadata);
+            signatureStream.Seek(0, SeekOrigin.End);
         }
 
         public void WriteChunk(ChunkSignature signature)


### PR DESCRIPTION
Instead of reading the full file to compute the checksums, the read buffer is used to generate checksums with TransformBlock and TransformBlockFinal.

The performance ain't really change much but I would assume it has a larger impact on very large files.

![image](https://cloud.githubusercontent.com/assets/1127727/4359347/1ea3f04a-4271-11e4-8df6-2f5b7959c839.png)
These numbers are based on the test "ExecuteWithTimings" (Signature Create + Delta Create + Patch application) and I added another test 500 MB based on 5000 files.
