### PR TITLE
Large files (> 2GB) and optimzations for new files

### DIFF
--- a/source/Octodiff/Core/BinaryDeltaWriter.cs
+++ b/source/Octodiff/Core/BinaryDeltaWriter.cs
@@ -47,7 +47,7 @@ namespace Octodiff.Core
                     read = source.Read(buffer, 0, buffer.Length);
 
                     writer.Write(buffer, 0, read);
-                } while (read == buffer.Length);
+                } while (read > 0);
             }
             finally
             {

--- a/source/Octodiff/Core/BinaryDeltaWriter.cs
+++ b/source/Octodiff/Core/BinaryDeltaWriter.cs
@@ -39,16 +39,15 @@ namespace Octodiff.Core
             {
                 source.Seek(offset, SeekOrigin.Begin);
 
-                var buffer = new byte[Math.Min((int)length, 1024 * 1024)];
+                var buffer = new byte[1024 * 1024];
 
                 int read;
-                long soFar = 0;
-                while ((read = source.Read(buffer, 0, (int)Math.Min(length - soFar, buffer.Length))) > 0)
+                do
                 {
-                    soFar += read;
+                    read = source.Read(buffer, 0, buffer.Length);
 
                     writer.Write(buffer, 0, read);
-                }
+                } while (read == buffer.Length);
             }
             finally
             {

--- a/source/Octodiff/Core/DeltaApplier.cs
+++ b/source/Octodiff/Core/DeltaApplier.cs
@@ -29,7 +29,7 @@ namespace Octodiff.Core
                         read = basisFileStream.Read(buffer, 0, buffer.Length);
 
                         outputStream.Write(buffer, 0, read);
-                    } while (read == buffer.Length);
+                    } while (read > 0);
                 });
 
             if (!SkipHashCheck)

--- a/source/Octodiff/Core/DeltaApplier.cs
+++ b/source/Octodiff/Core/DeltaApplier.cs
@@ -24,12 +24,12 @@ namespace Octodiff.Core
 
                     var buffer = new byte[4*1024*1024];
                     int read;
-                    long soFar = 0;
-                    while ((read = basisFileStream.Read(buffer, 0, (int)Math.Min(length - soFar, buffer.Length))) > 0)
+                    do
                     {
-                        soFar += read;
+                        read = basisFileStream.Read(buffer, 0, buffer.Length);
+
                         outputStream.Write(buffer, 0, read);
-                    }
+                    } while (read == buffer.Length);
                 });
 
             if (!SkipHashCheck)


### PR DESCRIPTION
Added changes to support synchronizing files larger than Int32.Max
Added optimization for when a file is new. When there are no chunks in the signature, the file doesn't exist on 'the other side'. It is therefor unnecessary to scan the file twice.
