### PR TITLE
Provide formatting/settings to help contributors

### DIFF
--- a/source/.editorconfig
+++ b/source/.editorconfig
@@ -1,0 +1,21 @@
+; EditorConfig to support per-solution formatting.
+; Use the EditorConfig VS add-in to make this work.
+; http://editorconfig.org/
+
+; This is the default for the codeline.
+root = true
+
+[*]
+end_of_line = CRLF
+
+[*.{cs,props,targets,xml,nuspec}]
+indent_style = space
+indent_size = 4
+
+[*.{config}]
+indent_style = space
+indent_size = 2
+
+[*.{csproj,resx}]
+indent_style = space
+indent_size = 2

--- a/source/Octodiff.vssettings
+++ b/source/Octodiff.vssettings
@@ -1,0 +1,67 @@
+<UserSettings>
+  <ApplicationIdentity version="11.0"/>
+  <ToolsOptions>
+    <ToolsOptionsCategory name="TextEditor" RegisteredName="TextEditor">
+      <ToolsOptionsSubCategory name="CSharp-Specific" RegisteredName="CSharp-Specific" PackageName="Visual C# Language Service Package">
+        <PropertyValue name="Formatting_TriggerOnBlockCompletion">1</PropertyValue>
+        <PropertyValue name="Formatting_TriggerOnPaste">1</PropertyValue>
+        <PropertyValue name="Formatting_TriggerOnStatementCompletion">1</PropertyValue>
+        <PropertyValue name="ImplementInterface_InsertRegionTags">0</PropertyValue>
+        <PropertyValue name="Indent_BlockContents">1</PropertyValue>
+        <PropertyValue name="Indent_Braces">0</PropertyValue>
+        <PropertyValue name="Indent_CaseContents">1</PropertyValue>
+        <PropertyValue name="Indent_CaseLabels">1</PropertyValue>
+        <PropertyValue name="Indent_FlushLabelsLeft">0</PropertyValue>
+        <PropertyValue name="Indent_UnindentLabels">1</PropertyValue>
+        <PropertyValue name="NewLines_AnonymousTypeInitializer_EachMember">1</PropertyValue>
+        <PropertyValue name="NewLines_Braces_AnonymousMethod">1</PropertyValue>
+        <PropertyValue name="NewLines_Braces_AnonymousTypeInitializer">1</PropertyValue>
+        <PropertyValue name="NewLines_Braces_ArrayInitializer">0</PropertyValue>
+        <PropertyValue name="NewLines_Braces_CollectionInitializer">0</PropertyValue>
+        <PropertyValue name="NewLines_Braces_ControlFlow">1</PropertyValue>
+        <PropertyValue name="NewLines_Braces_LambdaExpressionBody">1</PropertyValue>
+        <PropertyValue name="NewLines_Braces_Method">1</PropertyValue>
+        <PropertyValue name="NewLines_Braces_ObjectInitializer">1</PropertyValue>
+        <PropertyValue name="NewLines_Braces_Type">1</PropertyValue>
+        <PropertyValue name="NewLines_Keywords_Catch">1</PropertyValue>
+        <PropertyValue name="NewLines_Keywords_Else">1</PropertyValue>
+        <PropertyValue name="NewLines_Keywords_Finally">1</PropertyValue>
+        <PropertyValue name="NewLines_ObjectInitializer_EachMember">1</PropertyValue>
+        <PropertyValue name="NewLines_QueryExpression_EachClause">1</PropertyValue>
+        <PropertyValue name="RemoveUnusedUsings">1</PropertyValue>
+        <PropertyValue name="SortUsings">1</PropertyValue>
+        <PropertyValue name="SortUsings_PlaceSystemFirst">1</PropertyValue>
+        <PropertyValue name="Space_AfterBasesColon">1</PropertyValue>
+        <PropertyValue name="Space_AfterCast">0</PropertyValue>
+        <PropertyValue name="Space_AfterComma">1</PropertyValue>
+        <PropertyValue name="Space_AfterDot">0</PropertyValue>
+        <PropertyValue name="Space_AfterLambdaArrow">1</PropertyValue>
+        <PropertyValue name="Space_AfterMethodCallName">0</PropertyValue>
+        <PropertyValue name="Space_AfterMethodDeclarationName">0</PropertyValue>
+        <PropertyValue name="Space_AfterSemicolonsInForStatement">1</PropertyValue>
+        <PropertyValue name="Space_AroundBinaryOperator">1</PropertyValue>
+        <PropertyValue name="Space_BeforeBasesColon">1</PropertyValue>
+        <PropertyValue name="Space_BeforeComma">0</PropertyValue>
+        <PropertyValue name="Space_BeforeDot">0</PropertyValue>
+        <PropertyValue name="Space_BeforeLambdaArrow">1</PropertyValue>
+        <PropertyValue name="Space_BeforeOpenSquare">0</PropertyValue>
+        <PropertyValue name="Space_BeforeSemicolonsInForStatement">0</PropertyValue>
+        <PropertyValue name="Space_BetweenEmptyMethodCallParentheses">0</PropertyValue>
+        <PropertyValue name="Space_BetweenEmptyMethodDeclarationParentheses">0</PropertyValue>
+        <PropertyValue name="Space_BetweenEmptySquares">0</PropertyValue>
+        <PropertyValue name="Space_InControlFlowConstruct">1</PropertyValue>
+        <PropertyValue name="Space_Normalize">0</PropertyValue>
+        <PropertyValue name="Space_WithinCastParentheses">0</PropertyValue>
+        <PropertyValue name="Space_WithinExpressionParentheses">0</PropertyValue>
+        <PropertyValue name="Space_WithinMethodCallParentheses">0</PropertyValue>
+        <PropertyValue name="Space_WithinMethodDeclarationParentheses">0</PropertyValue>
+        <PropertyValue name="Space_WithinOtherParentheses">0</PropertyValue>
+        <PropertyValue name="Space_WithinSquares">0</PropertyValue>
+        <PropertyValue name="Wrapping_IgnoreSpacesAroundBinaryOperators">0</PropertyValue>
+        <PropertyValue name="Wrapping_IgnoreSpacesAroundVariableDeclaration">0</PropertyValue>
+        <PropertyValue name="Wrapping_KeepStatementsOnSingleLine">1</PropertyValue>
+        <PropertyValue name="Wrapping_PreserveSingleLine">1</PropertyValue>
+      </ToolsOptionsSubCategory>
+    </ToolsOptionsCategory>
+  </ToolsOptions>
+</UserSettings>


### PR DESCRIPTION
Reading the contributions guidelines is far less effective
than providing automated tooling that can deal with the
little big details like tabs and braces :).

Coupled with the EditorConfig extension (which also works
on VSCode and a myriad other text editor) as well as one
of the many extensions in VS that automatically load
.vssettings files alongside the solution (which can also
be imported manually of course), this ensures that a
contributor knows right-away what formatting to use,
without having to think.

I've adjusted by VS settings to the observed coding
conventions (which are pretty much the VS defaults,
but not Xamarin/Mono's defaults, for example ;)), and
exported the matching settings file. Likewise, I've
set up the .editorconfig with the spacing used in the
commonly edited files I found in the solution.