### PR TITLE
Introduce a new version of the Adler32 checksum that does a mod of 65521

### DIFF
--- a/source/Octodiff/Core/Adler32RollingChecksum.cs
+++ b/source/Octodiff/Core/Adler32RollingChecksum.cs
@@ -2,9 +2,10 @@ using System;
 
 namespace Octodiff.Core
 {
+    [Obsolete("This is non standard implimentation of Adler32, Adler32RollingChecksumV2 should be used instead.", false)]
     public class Adler32RollingChecksum : IRollingChecksum
     {
-        public string Name { get { return "Adler32"; } }
+        public string Name => "Adler32";
 
         public UInt32 Calculate(byte[] block, int offset, int count)
         {
@@ -16,7 +17,7 @@ namespace Octodiff.Core
                 a = (ushort)(z + a);
                 b = (ushort)(b + a);
             }
-            return (UInt32) ((b << 16) | a);
+            return (UInt32)((b << 16) | a);
         }
 
         public UInt32 Rotate(UInt32 checksum, byte remove, byte add, int chunkSize)
@@ -27,7 +28,7 @@ namespace Octodiff.Core
             a = (ushort)((a - remove + add));
             b = (ushort)((b - (chunkSize * remove) + a - 1));
 
-            return (UInt32) ((b << 16) | a);
+            return (UInt32)((b << 16) | a);
         }
     }
 }

--- a/source/Octodiff/Core/Adler32RollingChecksumV2.cs
+++ b/source/Octodiff/Core/Adler32RollingChecksumV2.cs
@@ -1,0 +1,33 @@
+﻿namespace Octodiff.Core
+{
+    public class Adler32RollingChecksumV2 : IRollingChecksum
+    {
+        public string Name => "Adler32V2";
+
+        private const ushort Modulus = 65521;
+
+        public uint Calculate(byte[] block, int offset, int count)
+        {
+            var a = 1;
+            var b = 0;
+            for (var i = offset; i < offset + count; i++)
+            {
+                var z = block[i];
+                a = (z + a) % Modulus;
+                b = (b + a) % Modulus;
+            }
+            return (uint)((b << 16) | a);
+        }
+
+        public uint Rotate(uint checksum, byte remove, byte add, int chunkSize)
+        {
+            var b = (ushort)(checksum >> 16 & 0xffff);
+            var a = (ushort)(checksum & 0xffff);
+
+            a = (ushort)((a - remove + add) % Modulus);
+            b = (ushort)((b - (chunkSize * remove) + a - 1) % Modulus);
+
+            return (uint)((b << 16) | a);
+        }
+    }
+}

--- a/source/Octodiff/Core/SupportedAlgorithms.cs
+++ b/source/Octodiff/Core/SupportedAlgorithms.cs
@@ -21,13 +21,22 @@ namespace Octodiff.Core
                 if (algorithm == "SHA1")
                     return Sha1();
 
-                throw new CompatibilityException(string.Format("The hash algorithm '{0}' is not supported in this version of Octodiff", algorithm));
+                throw new CompatibilityException(
+                    $"The hash algorithm '{algorithm}' is not supported in this version of Octodiff");
             }
         }
 
         public static class Checksum
         {
-            public static IRollingChecksum Adler32Rolling() { return new Adler32RollingChecksum();  }
+#pragma warning disable 618
+            public static IRollingChecksum Adler32Rolling(bool useV2 = false)
+            {
+                if (useV2)
+                    return new Adler32RollingChecksumV2();
+
+                return new Adler32RollingChecksum();
+            }
+#pragma warning restore 618
 
             public static IRollingChecksum Default()
             {
@@ -36,9 +45,15 @@ namespace Octodiff.Core
 
             public static IRollingChecksum Create(string algorithm)
             {
-                if (algorithm == "Adler32")
-                    return Adler32Rolling();
-                throw new CompatibilityException(string.Format("The rolling checksum algorithm '{0}' is not supported in this version of Octodiff", algorithm));
+                switch (algorithm)
+                {
+                    case "Adler32":
+                        return Adler32Rolling();
+                    case "Adler32V2":
+                        return Adler32Rolling(true);
+                }
+                throw new CompatibilityException(
+                    $"The rolling checksum algorithm '{algorithm}' is not supported in this version of Octodiff");
             }
         }
     }


### PR DESCRIPTION
Introduced a new implementation of the Adler32 checksum that does a modulus of 65521 instead of 65536.
We will default to using the old implementation as to not cause a breaking change. The old implementation is also marked as obsolete.

Fixes  #16