### PR TITLE
Adding the ability to work with patches in memory. 

### DIFF
--- a/source/Octodiff.Tests/StreamingPatchFixture.cs
+++ b/source/Octodiff.Tests/StreamingPatchFixture.cs
@@ -1,0 +1,84 @@
+using System;
+using System.IO;
+using System.Security.Cryptography;
+using NUnit.Framework;
+using Octodiff.Core;
+using Octodiff.Tests.Util;
+
+namespace Octodiff.Tests
+{
+    [TestFixture]
+    public class StreamingPatchFixture : CommandLineFixture
+    {
+        [Test]
+        [TestCase("SmallPackage1mb.zip", 10)]
+        [TestCase("SmallPackage10mb.zip", 100)]
+        [TestCase("SmallPackage100mb.zip", 1000)]
+        public void StreamingPatchingShouldResultInPerfectCopy(string name, int numberOfFiles)
+        {
+            var newName = Path.ChangeExtension(name, "2.zip");
+            var copyName = Path.ChangeExtension(name, "2_out.zip");
+            PackageGenerator.GeneratePackage(name, numberOfFiles);
+            PackageGenerator.ModifyPackage(name, newName, (int)(0.33 * numberOfFiles), (int)(0.10 * numberOfFiles));
+
+            Run("signature " + name + " " + name + ".sig");
+            Run("delta " + name + ".sig " + newName + " " + newName + ".delta");
+
+            // Patch
+            // todo: update this to use the command version when available
+            using (var basisStream = new FileStream(name, FileMode.Open, FileAccess.Read, FileShare.Read))
+            using (var newNameDeltaFileStream = new FileStream(newName + ".delta", FileMode.Open, FileAccess.Read, FileShare.Read))
+            using (var outStream = new FileStream(copyName, FileMode.Create, FileAccess.ReadWrite, FileShare.Read))
+            {
+                var newNameDelta = new BinaryDeltaStream(basisStream, newNameDeltaFileStream);
+                newNameDelta.Apply(outStream);
+            }
+
+            Assert.That(Sha1(newName), Is.EqualTo(Sha1(copyName)));
+        }
+
+        [Test]
+        [TestCase("SmallPackage1mb.zip", 10)]
+        [TestCase("SmallPackage10mb.zip", 100)]
+        [TestCase("SmallPackage100mb.zip", 1000)]
+        public void SecondLevelStreamingPatchingShouldResultInPerfectCopy(string name, int numberOfFiles)
+        {
+            var newName2 = Path.ChangeExtension(name, "2.zip");
+            var newName3 = Path.ChangeExtension(name, "3.zip");
+            var copyName = Path.ChangeExtension(name, "3_out.zip");
+            PackageGenerator.GeneratePackage(name, numberOfFiles);
+            PackageGenerator.ModifyPackage(name, newName2, (int)(0.33 * numberOfFiles), (int)(0.10 * numberOfFiles));
+            PackageGenerator.ModifyPackage(newName2, newName3, (int)(0.33 * numberOfFiles), (int)(0.10 * numberOfFiles));
+
+            Run("signature " + name + " " + name + ".sig");
+            Run("delta " + name + ".sig " + newName2 + " " + newName2 + ".delta");
+
+            Run("signature " + newName2 + " " + newName2 + ".sig");
+            Run("delta " + newName2 + ".sig " + newName3 + " " + newName3 + ".delta");
+
+            // Patch
+            // todo: update this to use the command version when available
+            using (var basisStream = new FileStream(name, FileMode.Open, FileAccess.Read, FileShare.Read))
+            using (var newName2DeltaFileStream = new FileStream(newName2 + ".delta", FileMode.Open, FileAccess.Read, FileShare.Read))
+            using (var newName3DeltaFileStream = new FileStream(newName3 + ".delta", FileMode.Open, FileAccess.Read, FileShare.Read))
+            using (var outStream = new FileStream(copyName, FileMode.Create, FileAccess.ReadWrite, FileShare.Read))
+            {
+                var newName2Delta = new BinaryDeltaStream(basisStream, newName2DeltaFileStream);
+                Assert.True(newName2Delta.VerifyHashInMemory(), "The first delta passed verification");
+                var newName3Delta = new BinaryDeltaStream(newName2Delta, newName3DeltaFileStream);
+                Assert.True(newName3Delta.VerifyHashInMemory(), "The second delta passed verification");
+                newName3Delta.Apply(outStream);
+            }
+
+            Assert.That(Sha1(newName3), Is.EqualTo(Sha1(copyName)));
+        }
+
+        static string Sha1(string fileName)
+        {
+            using (var s = new FileStream(fileName, FileMode.Open))
+            {
+                return BitConverter.ToString(SHA1.Create().ComputeHash(s)).Replace("-", "");
+            }
+        }
+    }
+}

--- a/source/Octodiff/Core/BinaryDeltaStream.cs
+++ b/source/Octodiff/Core/BinaryDeltaStream.cs
@@ -1,0 +1,179 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Octodiff.Diagnostics;
+
+namespace Octodiff.Core
+{
+
+    public class BinaryDeltaStream : IDeltaStream
+    {
+        class CommandData
+        {
+            public bool IsOrigin { get; set; }
+            public long CommandStartLocation { get; set; }
+            public long DestinationFileLocation { get; set; }
+            public long SrcLocation { get; set; }
+            public long Length { get; set; }
+        }
+
+        private readonly BinaryReader reader;
+        private byte[] expectedHash;
+        private IHashAlgorithm hashAlgorithm;
+        private bool hasReadMetadata;
+        SortedList<long, CommandData> commands = new SortedList<long, CommandData>();
+        public long Length { get; private set; }
+
+        private Func<byte[], long, int, int?, int> OriginRead { get; }
+        private Func<byte[], long, int, int?, int> DeltaRead { get; }
+
+        public BinaryDeltaStream(Stream basisStream, Stream delta)
+        {
+            this.reader = new BinaryReader(delta);
+
+            OriginRead = (byte[] buffer, long startBytes, int offset, int? count) =>
+            {
+                basisStream.Seek(startBytes, SeekOrigin.Begin);
+                return basisStream.Read(buffer, offset, count ?? buffer.Length);
+            };
+            DeltaRead = (byte[] buffer, long startBytes, int offset, int? count) =>
+            {
+                reader.BaseStream.Seek(startBytes, SeekOrigin.Begin);
+                return reader.BaseStream.Read(buffer, offset, count ?? buffer.Length);
+            };
+        }
+
+        public BinaryDeltaStream(BinaryDeltaStream basisStream, Stream delta)
+        {
+            OriginRead = (byte[] buffer, long startBytes, int offset, int? count) =>
+            {
+                return basisStream.Read(buffer, startBytes, offset, count);
+            };
+            DeltaRead = (byte[] buffer, long startBytes, int offset, int? count) =>
+            {
+                reader.BaseStream.Seek(startBytes, SeekOrigin.Begin);
+                return reader.BaseStream.Read(buffer, offset, count ?? buffer.Length);
+            };
+            this.reader = new BinaryReader(delta);
+        }
+
+        public byte[] ExpectedHash
+        {
+            get
+            {
+                EnsureMetadata();
+                return expectedHash;
+            }
+        }
+
+        public IHashAlgorithm HashAlgorithm
+        {
+            get
+            {
+                EnsureMetadata();
+                return hashAlgorithm;
+            }
+        }
+
+
+        void EnsureMetadata()
+        {
+            if (hasReadMetadata)
+                return;
+
+            reader.BaseStream.Seek(0, SeekOrigin.Begin);
+
+            var first = reader.ReadBytes(BinaryFormat.DeltaHeader.Length);
+            if (!StructuralComparisons.StructuralEqualityComparer.Equals(first, BinaryFormat.DeltaHeader))
+                throw new CorruptFileFormatException("The delta file appears to be corrupt.");
+
+            var version = reader.ReadByte();
+            if (version != BinaryFormat.Version)
+                throw new CorruptFileFormatException("The delta file uses a newer file format than this program can handle.");
+
+            var hashAlgorithmName = reader.ReadString();
+            hashAlgorithm = SupportedAlgorithms.Hashing.Create(hashAlgorithmName);
+
+            var hashLength = reader.ReadInt32();
+            expectedHash = reader.ReadBytes(hashLength);
+            var endOfMeta = reader.ReadBytes(BinaryFormat.EndOfMetadata.Length);
+            if (!StructuralComparisons.StructuralEqualityComparer.Equals(BinaryFormat.EndOfMetadata, endOfMeta))
+                throw new CorruptFileFormatException("The signature file appears to be corrupt.");
+
+
+            var fileLength = reader.BaseStream.Length;
+            //long currentLocation = 0;
+            long outputLocation = 0;
+
+            while (reader.BaseStream.Position != fileLength)
+            {
+                var b = reader.ReadByte();
+
+                if (b == BinaryFormat.CopyCommand)
+                {
+                    var start = reader.ReadInt64();
+                    var length = reader.ReadInt64();
+                    commands.Add(outputLocation, new CommandData
+                    {
+                        IsOrigin = true,
+                        DestinationFileLocation = outputLocation,
+                        Length = length,
+                        CommandStartLocation = reader.BaseStream.Position - (sizeof(long) * 2),
+                    });
+                    outputLocation += length;
+                }
+                else if (b == BinaryFormat.DataCommand)
+                {
+                    var length = reader.ReadInt64();
+                    commands.Add(outputLocation, new CommandData
+                    {
+                        IsOrigin = false,
+                        DestinationFileLocation = outputLocation,
+                        Length = length,
+                        CommandStartLocation = reader.BaseStream.Position - (sizeof(long) * 2),
+
+                    });
+                    reader.BaseStream.Seek(length, SeekOrigin.Current);
+                    outputLocation += length;
+
+                }
+            }
+            Length = commands.Last().Key + commands.Last().Value.Length;
+
+
+
+            hasReadMetadata = true;
+        }
+
+        public int Read(byte[] buffer, long startBytes, int offset = 0, int? count = null)
+        {
+            var localCount = count == null ? buffer.Length - offset : Math.Min(buffer.Length - offset, count.Value);
+            var fileLength = reader.BaseStream.Length;
+
+            EnsureMetadata();
+            int currentBytes = 0;
+
+            while ((startBytes + currentBytes) < Length && localCount > currentBytes)
+            {
+                var currentStart = startBytes + currentBytes;
+                var nextCmd = commands.Where(s => s.Key <= currentStart).Last().Value;
+
+                var start = nextCmd.SrcLocation + (currentStart - nextCmd.DestinationFileLocation);
+                var length = nextCmd.Length - (currentStart - nextCmd.DestinationFileLocation);
+
+                int read;
+                long soFar = 0;
+                while ((read = (nextCmd.IsOrigin ? OriginRead : DeltaRead).Invoke(buffer, start, currentBytes + offset, (int)Math.Min(length - soFar, localCount - currentBytes))) > 0)
+                {
+                    soFar += read;
+                    currentBytes += read;
+                }
+
+            }
+            return currentBytes;
+        }
+    }
+}

--- a/source/Octodiff/Core/DeltaApplier.cs
+++ b/source/Octodiff/Core/DeltaApplier.cs
@@ -33,7 +33,7 @@ namespace Octodiff.Core
             var buffer = new byte[4 * 1024 * 1024];
             var offset = 0L;
             var currentSize = 0;
-            while ((currentSize = delta.Read(buffer, offset)) > 0)
+            while ((currentSize = delta.ReadAt(buffer, offset)) > 0)
             {
                 outputStream.Write(buffer, 0, currentSize);
                 offset += currentSize;
@@ -61,7 +61,6 @@ namespace Octodiff.Core
 
             return StructuralComparisons.StructuralEqualityComparer.Equals(sourceFileHash, actualHash);
         }
-
 
         public static void Apply(this IDeltaReader delta, Stream basisFileStream, Stream outputStream, bool SkipHashCheck = false)
         {

--- a/source/Octodiff/Core/DeltaApplier.cs
+++ b/source/Octodiff/Core/DeltaApplier.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.IO;
 using Octodiff.Diagnostics;
 
@@ -16,13 +17,61 @@ namespace Octodiff.Core
 
         public void Apply(Stream basisFileStream, IDeltaReader delta, Stream outputStream)
         {
+            delta.Apply(basisFileStream, outputStream, SkipHashCheck);
+        }
+
+        public void Apply(IDeltaStream delta, Stream outputStream)
+        {
+            delta.Apply(outputStream, SkipHashCheck);
+        }
+    }
+
+    public static class DeltaApplierExtensionMethods
+    {
+        public static void Apply(this IDeltaStream delta, Stream outputStream, bool SkipHashCheck = false)
+        {
+            var buffer = new byte[4 * 1024 * 1024];
+            var offset = 0L;
+            var currentSize = 0;
+            while ((currentSize = delta.Read(buffer, offset)) > 0)
+            {
+                outputStream.Write(buffer, 0, currentSize);
+                offset += currentSize;
+            }
+
+            if (!SkipHashCheck)
+            {
+                outputStream.Flush();
+                if (!delta.IsHashValid(outputStream))
+                {
+                    throw new UsageException("Verification of the patched file failed. The SHA1 hash of the patch result file, and the file that was used as input for the delta, do not match. This can happen if the basis file changed since the signatures were calculated.");
+                }
+
+            }
+        }
+
+        public static bool IsHashValid(this IDeltaStream delta, Stream outputStream)
+        {
+            outputStream.Seek(0, SeekOrigin.Begin);
+
+            var sourceFileHash = delta.ExpectedHash;
+            var algorithm = delta.HashAlgorithm;
+
+            var actualHash = algorithm.ComputeHash(outputStream);
+
+            return StructuralComparisons.StructuralEqualityComparer.Equals(sourceFileHash, actualHash);
+        }
+
+
+        public static void Apply(this IDeltaReader delta, Stream basisFileStream, Stream outputStream, bool SkipHashCheck = false)
+        {
             delta.Apply(
                 writeData: (data) => outputStream.Write(data, 0, data.Length),
                 copy: (startPosition, length) =>
                 {
                     basisFileStream.Seek(startPosition, SeekOrigin.Begin);
 
-                    var buffer = new byte[4*1024*1024];
+                    var buffer = new byte[4 * 1024 * 1024];
                     int read;
                     long soFar = 0;
                     while ((read = basisFileStream.Read(buffer, 0, (int)Math.Min(length - soFar, buffer.Length))) > 0)
@@ -34,16 +83,23 @@ namespace Octodiff.Core
 
             if (!SkipHashCheck)
             {
-                outputStream.Seek(0, SeekOrigin.Begin);
-
-                var sourceFileHash = delta.ExpectedHash;
-                var algorithm = delta.HashAlgorithm;
-
-                var actualHash = algorithm.ComputeHash(outputStream);
-
-                if (!StructuralComparisons.StructuralEqualityComparer.Equals(sourceFileHash, actualHash))
+                if (!delta.IsHashValid(outputStream))
+                {
                     throw new UsageException("Verification of the patched file failed. The SHA1 hash of the patch result file, and the file that was used as input for the delta, do not match. This can happen if the basis file changed since the signatures were calculated.");
+                }
             }
+        }
+
+        public static bool IsHashValid(this IDeltaReader delta, Stream outputStream)
+        {
+            outputStream.Seek(0, SeekOrigin.Begin);
+
+            var sourceFileHash = delta.ExpectedHash;
+            var algorithm = delta.HashAlgorithm;
+
+            var actualHash = algorithm.ComputeHash(outputStream);
+
+            return StructuralComparisons.StructuralEqualityComparer.Equals(sourceFileHash, actualHash);
         }
     }
 }

--- a/source/Octodiff/Core/IDeltaStream.cs
+++ b/source/Octodiff/Core/IDeltaStream.cs
@@ -1,0 +1,11 @@
+﻿namespace Octodiff.Core
+{
+    public interface IDeltaStream
+    {
+        byte[] ExpectedHash { get; }
+        IHashAlgorithm HashAlgorithm { get; }
+        long Length { get; }
+
+        int Read(byte[] buffer, long startBytes, int offset = 0, int? count = null);
+    }
+}

--- a/source/Octodiff/Core/IDeltaStream.cs
+++ b/source/Octodiff/Core/IDeltaStream.cs
@@ -6,6 +6,6 @@
         IHashAlgorithm HashAlgorithm { get; }
         long Length { get; }
 
-        int Read(byte[] buffer, long startBytes, int offset = 0, int? count = null);
+        int ReadAt(byte[] buffer, long startBytes, int offset = 0, int? count = null);
     }
 }


### PR DESCRIPTION
This PR adds the ability to chain patch files for handling incremental diffs without having to write the entire file to disk at each step. It also enables working with large files (>2GB) in memory.

I didn't see a good way to accept an unknown number of patch files for the command line version. If you can give me some pointers, I'll try to get that implemented. Otherwise, this will only work for the library version. 