### PR TITLE
Core/minor version bump

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ on:
 
 env:
   OCTOVERSION_CurrentBranch: ${{ github.head_ref || github.ref }}
-  #OCTOVERSION_Patch: ${{ github.run_number }}
+  OCTOVERSION_Patch: ${{ github.run_number }}
 
 jobs:
   test-linux:


### PR DESCRIPTION
This is to increment the minor version and use `github.run_number` for versioning.