### PR TITLE
Adding Octopus prefix to avoid references dependency confusion

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -107,7 +107,7 @@ jobs:
         echo "OCTOPUSDEPLOY_Space=Core Platform" >> $env:GITHUB_ENV
         $env:repo_name = $env:GITHUB_REPOSITORY.Substring($env:GITHUB_REPOSITORY.lastIndexOf('/')+1)        
         echo "OCTOPUSDEPLOY_Project=$env:repo_name" >> $env:GITHUB_ENV
-        echo "OCTOPUSDEPLOY_Package=$env:repo_name" >> $env:GITHUB_ENV
+        echo "OCTOPUSDEPLOY_Package=Octopus.Octodiff" >> $env:GITHUB_ENV
 
     - name: Push to Octopus 🐙
       uses: OctopusDeploy/push-package-action@v1

--- a/source/Octodiff/Octodiff.csproj
+++ b/source/Octodiff/Octodiff.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyName>Octodiff</AssemblyName>
-    <PackageId>Octodiff</PackageId>
+    <PackageId>Octopus.Octodiff</PackageId>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <PackageProjectUrl>https://github.com/OctopusDeploy/Octodiff</PackageProjectUrl>
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>


### PR DESCRIPTION
This work is to address [issue 37](https://github.com/OctopusDeploy/Octodiff/issues/37).

Updating `Octodiff` package to `Octopus.Octodiff`