### PR TITLE
Reuse buffer to avoid memory spikes

### DIFF
--- a/source/Octodiff/CommandLine/ExplainDeltaCommand.cs
+++ b/source/Octodiff/CommandLine/ExplainDeltaCommand.cs
@@ -42,16 +42,16 @@ namespace Octodiff.CommandLine
             {
                 var reader = new BinaryDeltaReader(deltaStream, new NullProgressReporter());
 
-                reader.Apply(data =>
+                reader.Apply((data, offset, count) =>
                 {
-                    if (data.Length > 20)
+                    if (count > 20)
                     {
-                        Console.WriteLine("Data: ({0} bytes): {1}...", data.Length,
-                            BitConverter.ToString(data.Take(20).ToArray()));
+                        Console.WriteLine("Data: ({0} bytes): {1}...", count,
+                            BitConverter.ToString(data.Skip(offset).Take(20).ToArray()));
                     }
                     else
                     {
-                        Console.WriteLine("Data: ({0} bytes): {1}", data.Length, BitConverter.ToString(data.ToArray()));                        
+                        Console.WriteLine("Data: ({0} bytes): {1}", count, BitConverter.ToString(data.Skip(offset).Take(count).ToArray()));                        
                     }
                 }, 
                 (start, offset) => Console.WriteLine("Copy: {0:X} to {1:X}", start, offset));

--- a/source/Octodiff/Core/IDeltaReader.cs
+++ b/source/Octodiff/Core/IDeltaReader.cs
@@ -6,8 +6,16 @@ namespace Octodiff.Core
     {
         byte[] ExpectedHash { get; }
         IHashAlgorithm HashAlgorithm { get; }
+
+        /// <summary>
+        /// Reads the delta file.
+        /// This method will invoke the Action to copy the data from the original file multiple times if needed.
+        /// This method will also invoke the Action to write data from the delta file to the destination file multiple times if needed.
+        /// </summary>
+        /// <param name="writeData">Action to write data from the delta file to the destination file. Parameters: buffer, offset and count.</param>
+        /// <param name="copy">Action to copy data from the original file to the destination file. Parameters: offset and count.</param>
         void Apply(
-            Action<byte[]> writeData,
+            Action<byte[], int, int> writeData,
             Action<long, long> copy
             );
     }


### PR DESCRIPTION
We improved the use of memory to avoid memory spikes and pod restarts in Octopus server.

Memory allocated before 102 GB. After 8 MB. See details below.

[sc-25897]

# Before

|                  Method |        Mean |     Error |    StdDev |        Gen0 |        Gen1 |        Gen2 |    Allocated |
|------------------------ |------------:|----------:|----------:|------------:|------------:|------------:|-------------:|
| ApplyBigDelta_Different |    16.19 ms |  0.311 ms |  0.576 ms |    375.0000 |    375.0000 |    375.0000 |        50 MB |
| ApplyBigDelta_Identical | 2,066.69 ms | 41.238 ms | 98.802 ms | 363000.0000 | 363000.0000 | 363000.0000 | 102400.77 MB |

|                  Method |        Mean |     Error |    StdDev |        Gen0 |        Gen1 |        Gen2 |    Allocated |
|------------------------ |------------:|----------:|----------:|------------:|------------:|------------:|-------------:|
| ApplyBigDelta_Different |    16.36 ms |  0.279 ms |  0.261 ms |    375.0000 |    375.0000 |    375.0000 |        50 MB |
| ApplyBigDelta_Identical | 1,983.46 ms | 37.114 ms | 93.113 ms | 364000.0000 | 364000.0000 | 364000.0000 | 102400.77 MB |

# After

|                  Method |     Mean |     Error |    StdDev |    Gen0 |    Gen1 |    Gen2 | Allocated |
|------------------------ |---------:|----------:|----------:|--------:|--------:|--------:|----------:|
| ApplyBigDelta_Different | 4.577 ms | 0.0874 ms | 0.0935 ms | 78.1250 | 78.1250 | 78.1250 |      8 MB |
| ApplyBigDelta_Identical | 4.055 ms | 0.0388 ms | 0.0344 ms | 62.5000 | 62.5000 | 62.5000 |      8 MB |

|                  Method |     Mean |     Error |    StdDev |    Gen0 |    Gen1 |    Gen2 | Allocated |
|------------------------ |---------:|----------:|----------:|--------:|--------:|--------:|----------:|
| ApplyBigDelta_Different | 4.319 ms | 0.0842 ms | 0.1475 ms | 78.1250 | 78.1250 | 78.1250 |      8 MB |
| ApplyBigDelta_Identical | 3.978 ms | 0.0265 ms | 0.0235 ms | 62.5000 | 62.5000 | 62.5000 |      8 MB |