### PR TITLE
Add PackageLicenseExpression to .csproj

### DIFF
--- a/source/Octodiff/Octodiff.csproj
+++ b/source/Octodiff/Octodiff.csproj
@@ -8,7 +8,6 @@
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <PackageProjectUrl>https://github.com/OctopusDeploy/Octodiff</PackageProjectUrl>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
-    <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
     <Authors>Octopus Deploy</Authors>
     <Copyright>Octopus Deploy Pty Ltd</Copyright>
     <PackageTags>tool</PackageTags>

--- a/source/Octodiff/Octodiff.csproj
+++ b/source/Octodiff/Octodiff.csproj
@@ -7,6 +7,7 @@
     <PackageId>Octopus.Octodiff</PackageId>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <PackageProjectUrl>https://github.com/OctopusDeploy/Octodiff</PackageProjectUrl>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
     <Authors>Octopus Deploy</Authors>
     <Copyright>Octopus Deploy Pty Ltd</Copyright>


### PR DESCRIPTION
Our [credits](https://octopus.com/docs/credits) page is currently showing Custom for Octodiff. This PR will ensure it gets picked up as `Apache-2.0`.